### PR TITLE
:sparkles: feat: フロントローカルストーレージにトークンを持たせる機能追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -26,7 +26,7 @@ class SessionsController < ApplicationController
         # redirect_to login_path, notice: message
         # notice: message
 
-        render json: {status: 500}
+        render json: {error: message}, status: 401
     end
   end
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,17 @@ import Posts from './features/posts/Posts'
 import LoginForm from './features/login/LoginForm'
 import { useAppSelector } from './app/hooks'
 import { selectUser } from './features/login/LoginSlice'
+import { useEffect, useState } from 'react'
 
 function App() {
+  // TODO: remove accesss token with hard code for testing purpose.
+  // localStorage.removeItem('accessToken')
+  const token = localStorage.getItem('accessToken')
   const login = useAppSelector(selectUser)
 
   return (
     <div>
-      {login.token ? (
+      {token || login.token ? (
         <div className="App">
           <Posts />
         </div>

--- a/frontend/src/features/login/LoginSlice.tsx
+++ b/frontend/src/features/login/LoginSlice.tsx
@@ -32,7 +32,11 @@ export const findUserAsync = createAsyncThunk(
   async (payload: LoginData) => {
     const response = await findUser(payload)
 
-    console.log('response :>> ', response)
+    // TODO: this is not the best way to store token, just uding it alternatively.
+    // TODO: add refresh token to local storage, also logout feature to clear the local storage
+    if (response.token) {
+      localStorage.setItem('accessToken', response.token)
+    }
     return response
   }
 )

--- a/frontend/src/features/login/loginAPI.ts
+++ b/frontend/src/features/login/loginAPI.ts
@@ -4,7 +4,6 @@ const API_URL = 'http://localhost:3001'
 
 export const findUser = async (payload: LoginData) => {
   const user = payload
-  console.log('user :>> ', user)
   return fetch(`${API_URL}/login`, {
     method: 'POST',
     headers: {
@@ -14,9 +13,18 @@ export const findUser = async (payload: LoginData) => {
       ...user,
     }),
   })
-    .then((response) => response.json())
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Authentication failed')
+      }
+
+      return response.json()
+    })
     .catch((error) => {
       console.log('error :>> ', error)
+      alert(
+        'your username and password are incorrect.\nInput\nusername: ai\npassword: 123'
+      )
       return {}
     })
 }


### PR DESCRIPTION
## やったこと

[🐛 fix: fetchUserエラー時サーバー側でエラー出すよう追加](https://github.com/aiueda27/habit-notification/commit/944c567aea9b3e0bcfba28baf37a69fe4a838823)

[✨ feat: Tokenをローカルストーレージに保存する機能追加](https://github.com/aiueda27/habit-notification/commit/11cda788f16db603eaa8cdf9c166492f53cb8552)

[✨ feat: fetchUserのフロント側エラーハンドリング追加](https://github.com/aiueda27/habit-notification/commit/e2c18611e5885d18e2704e74aeb82cfaaf429e81)


## やらないこと
ローカルストーレージに保存するやり方はXXRの可能性もあり本当は良くないが、一旦これで実装
ローカルストーレージから削除ロジックを入れていない（ログアウトのタイミングで走らせる）
リフレッシュトークンなどの機能追加

## エビデンス

https://github.com/aiueda27/habit-notification/assets/125167145/bcc8a5df-319b-4bfd-8572-b076e6992738


